### PR TITLE
Fix None-valued OpenAI request params for GPT-5 models

### DIFF
--- a/epub_translator/llm/executor.py
+++ b/epub_translator/llm/executor.py
@@ -157,16 +157,19 @@ class LLMExecutor:
                     }
                 )
 
-        stream = self._client.chat.completions.create(
-            model=self._model_name,
-            messages=messages,
-            stream=True,
-            stream_options={"include_usage": True},
-            top_p=top_p,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            extra_body=self._extra_body,
-        )
+        request_kwargs: dict[str, object] = {
+            "model": self._model_name,
+            "messages": messages,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "top_p": top_p,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "extra_body": self._extra_body,
+        }
+        request_kwargs = {key: value for key, value in request_kwargs.items() if value is not None}
+
+        stream = self._client.chat.completions.create(**request_kwargs)
         buffer = StringIO()
         for chunk in stream:
             if chunk.choices and chunk.choices[0].delta.content:

--- a/epub_translator/llm/executor.py
+++ b/epub_translator/llm/executor.py
@@ -3,7 +3,7 @@ from io import StringIO
 from logging import Logger
 from time import sleep
 
-from openai import OpenAI
+from openai import OpenAI, omit
 from openai.types.chat import ChatCompletionMessageParam
 
 from .error import is_retry_error
@@ -157,19 +157,16 @@ class LLMExecutor:
                     }
                 )
 
-        request_kwargs: dict[str, object] = {
-            "model": self._model_name,
-            "messages": messages,
-            "stream": True,
-            "stream_options": {"include_usage": True},
-            "top_p": top_p,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "extra_body": self._extra_body,
-        }
-        request_kwargs = {key: value for key, value in request_kwargs.items() if value is not None}
-
-        stream = self._client.chat.completions.create(**request_kwargs)
+        stream = self._client.chat.completions.create(
+            model=self._model_name,
+            messages=messages,
+            stream=True,
+            stream_options={"include_usage": True},
+            top_p=top_p if top_p is not None else omit,
+            temperature=temperature if temperature is not None else omit,
+            max_tokens=max_tokens if max_tokens is not None else omit,
+            extra_body=self._extra_body,
+        )
         buffer = StringIO()
         for chunk in stream:
             if chunk.choices and chunk.choices[0].delta.content:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "epub-translator"
-version = "0.1.9"
+version = "0.1.10"
 description = "Translate the epub book using LLM. The translated book will retain the original text and list the translated text side by side with the original text."
 keywords = ["epub", "llm", "translation", "translator"]
 authors = [


### PR DESCRIPTION
## Summary
- omit `None`-valued request parameters before calling `chat.completions.create`
- prevent `max_tokens=null` from being sent to GPT-5 models, which reject it with a 400 error
- bump package version to `0.1.10`

## Testing
- not run

Closes #135