### PR TITLE
fix(xml): support unquoted HTML named entities

### DIFF
--- a/epub_translator/xml/xml_like.py
+++ b/epub_translator/xml/xml_like.py
@@ -236,10 +236,17 @@ def _normalize_unquoted_html_entities(content: str) -> str:
     result: list[str] = []
     index = 0
     quote: str | None = None
+    in_tag = False
 
     while index < len(content):
         char = content[index]
-        if char in ("'", '"'):
+
+        if char == "<" and quote is None:
+            in_tag = True
+        elif char == ">" and quote is None:
+            in_tag = False
+
+        if in_tag and char in ("'", '"'):
             quote = None if quote == char else char if quote is None else quote
             result.append(char)
             index += 1

--- a/epub_translator/xml/xml_like.py
+++ b/epub_translator/xml/xml_like.py
@@ -1,6 +1,7 @@
 import io
 import re
 import warnings
+from html.entities import html5
 from typing import IO
 from xml.etree.ElementTree import Element, fromstring, tostring
 
@@ -31,6 +32,8 @@ _ROOT_NAMESPACES = {
 _ENCODING_PATTERN = re.compile(r'encoding\s*=\s*["\']([^"\']+)["\']', re.IGNORECASE)
 _FIRST_ELEMENT_PATTERN = re.compile(r"<(?![?!])[a-zA-Z]")
 _NAMESPACE_IN_TAG = re.compile(r"\{([^}]+)\}")
+_HTML_NAMED_ENTITY_PATTERN = re.compile(r"&([A-Za-z][A-Za-z0-9]+);")
+_XML_PREDEFINED_ENTITIES = {"amp", "lt", "gt", "apos", "quot"}
 
 # When an attribute name exists in multiple namespaces (e.g., 'type' in XHTML and EPUB ops),
 # _attr_to_namespace only records ONE namespace per attribute name. During serialization,
@@ -66,6 +69,7 @@ class XMLLikeNode:
         try:
             # 不必判断类型，这是一个防御性极强的函数，可做到 shit >> XML
             xml_content = self_close_void_elements(xml_content)
+            xml_content = _normalize_unquoted_html_entities(xml_content)
             self.element = self._extract_and_clean_namespaces(
                 element=fromstring(xml_content),
             )
@@ -226,3 +230,43 @@ class XMLLikeNode:
             xml_string = pattern.sub(replacement, xml_string)
 
         return xml_string
+
+
+def _normalize_unquoted_html_entities(content: str) -> str:
+    result: list[str] = []
+    index = 0
+    quote: str | None = None
+
+    while index < len(content):
+        char = content[index]
+        if char in ("'", '"'):
+            quote = None if quote == char else char if quote is None else quote
+            result.append(char)
+            index += 1
+            continue
+
+        if quote is None and char == "&":
+            match = _HTML_NAMED_ENTITY_PATTERN.match(content, index)
+            if match:
+                entity_name = match.group(1)
+                replacement = _html_entity_to_numeric_reference(entity_name)
+                if replacement is not None:
+                    result.append(replacement)
+                    index = match.end()
+                    continue
+
+        result.append(char)
+        index += 1
+
+    return "".join(result)
+
+
+def _html_entity_to_numeric_reference(entity_name: str) -> str | None:
+    if entity_name in _XML_PREDEFINED_ENTITIES:
+        return None
+
+    value = html5.get(f"{entity_name};")
+    if value is None:
+        return None
+
+    return "".join(f"&#{ord(char)};" for char in value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "epub-translator"
-version = "0.1.10"
+version = "0.1.11"
 description = "Translate the epub book using LLM. The translated book will retain the original text and list the translated text side by side with the original text."
 keywords = ["epub", "llm", "translation", "translator"]
 authors = [

--- a/tests/test_xml_like.py
+++ b/tests/test_xml_like.py
@@ -291,6 +291,29 @@ class TestXMLLikeNode(unittest.TestCase):
         self.assertIn("<m:mo>", result, "m:mo prefix missing")
         self.assertIn("<m:mn>", result, "m:mn prefix missing")
 
+    def test_unquoted_html_named_entities_are_supported(self):
+        """测试引号外的 HTML 命名实体会被规范化为 XML 可解析内容"""
+        original_content = b"""<html>
+<body><p>A&nbsp;B &copy; &mdash; &lt;tag&gt; &#169; &#xA0;</p></body>
+</html>"""
+
+        input_file = io.BytesIO(original_content)
+        node = XMLLikeNode(input_file)
+
+        p = node.element.find(".//p")
+        self.assertIsNotNone(p)
+        self.assertEqual(p.text, "A\u00a0B \u00a9 \u2014 <tag> \u00a9 \u00a0")
+
+    def test_quoted_html_named_entities_are_left_unchanged(self):
+        """测试引号内的 HTML 命名实体不会被规范化"""
+        original_content = b"""<html>
+<body><p title="A&nbsp;B">Hello</p></body>
+</html>"""
+
+        input_file = io.BytesIO(original_content)
+        with self.assertRaises(ValueError):
+            XMLLikeNode(input_file)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_xml_like.py
+++ b/tests/test_xml_like.py
@@ -302,7 +302,22 @@ class TestXMLLikeNode(unittest.TestCase):
 
         p = node.element.find(".//p")
         self.assertIsNotNone(p)
+        p = cast(Element, p)
         self.assertEqual(p.text, "A\u00a0B \u00a9 \u2014 <tag> \u00a9 \u00a0")
+
+    def test_apostrophe_in_text_does_not_disable_html_entity_normalization(self):
+        """测试正文中的 apostrophe 不会影响后续 HTML 命名实体规范化"""
+        original_content = b"""<html>
+<body><p>It's &copy;</p></body>
+</html>"""
+
+        input_file = io.BytesIO(original_content)
+        node = XMLLikeNode(input_file)
+
+        p = node.element.find(".//p")
+        self.assertIsNotNone(p)
+        p = cast(Element, p)
+        self.assertEqual(p.text, "It's \u00a9")
 
     def test_quoted_html_named_entities_are_left_unchanged(self):
         """测试引号内的 HTML 命名实体不会被规范化"""


### PR DESCRIPTION
## Summary
- normalize known HTML named entities outside quoted sections before XML parsing
- preserve XML predefined entities, numeric references, unknown entities, and quoted content
- bump package version to 0.1.11

## Tests
- poetry run ruff check epub_translator/xml/xml_like.py tests/test_xml_like.py pyproject.toml
- poetry run pytest